### PR TITLE
Update method names

### DIFF
--- a/quotesbot/spiders/toscrape-css.py
+++ b/quotesbot/spiders/toscrape-css.py
@@ -11,12 +11,12 @@ class ToScrapeCSSSpider(scrapy.Spider):
     def parse(self, response):
         for quote in response.css("div.quote"):
             yield {
-                'text': quote.css("span.text::text").extract_first(),
-                'author': quote.css("small.author::text").extract_first(),
-                'tags': quote.css("div.tags > a.tag::text").extract()
+                'text': quote.css("span.text::text").get(),
+                'author': quote.css("small.author::text").get(),
+                'tags': quote.css("div.tags > a.tag::text").getall()
             }
 
-        next_page_url = response.css("li.next > a::attr(href)").extract_first()
+        next_page_url = response.css("li.next > a::attr(href)").get()
         if next_page_url is not None:
             yield scrapy.Request(response.urljoin(next_page_url))
 

--- a/quotesbot/spiders/toscrape-xpath.py
+++ b/quotesbot/spiders/toscrape-xpath.py
@@ -11,12 +11,12 @@ class ToScrapeSpiderXPath(scrapy.Spider):
     def parse(self, response):
         for quote in response.xpath('//div[@class="quote"]'):
             yield {
-                'text': quote.xpath('./span[@class="text"]/text()').extract_first(),
-                'author': quote.xpath('.//small[@class="author"]/text()').extract_first(),
-                'tags': quote.xpath('.//div[@class="tags"]/a[@class="tag"]/text()').extract()
+                'text': quote.xpath('./span[@class="text"]/text()').get(),
+                'author': quote.xpath('.//small[@class="author"]/text()').get(),
+                'tags': quote.xpath('.//div[@class="tags"]/a[@class="tag"]/text()').getall()
             }
 
-        next_page_url = response.xpath('//li[@class="next"]/a/@href').extract_first()
+        next_page_url = response.xpath('//li[@class="next"]/a/@href').get()
         if next_page_url is not None:
             yield scrapy.Request(response.urljoin(next_page_url))
 


### PR DESCRIPTION
Although method 'extract' and 'extract_first' are still supported, the docs are now using 'getall' and 'get' respectively instead. Thus the code here using old method names can be confusing for newcomers who have just finished the tutorial. I have updated the two .py files to match the new standard in accordance with the docs now.